### PR TITLE
Refactor unit tests to work correctly within the go test infrastructure

### DIFF
--- a/tagger_test.go
+++ b/tagger_test.go
@@ -33,138 +33,391 @@ POSSIBILITY OF SUCH DAMAGE.
 package tagger
 
 import (
-	"fmt"
+	"log"
+	"os"
 	"testing"
 )
 
-// This function is the testing function and can be the only one
-// because the others need to have something passed into them
-// go test does not state which functions are run when and in what
-// order so having multiple functions with possible uninitialized
-// variables would be an impropper use case or test case because
-// I am not controlling when those said functions are given that value
-func TestMain(t *testing.T) {
-	// There is not a point in giving the MkTagger function something that is not
-	// a pointer because the compiler will not let the code compile if a pointer
-	// is not given
-	copyrightTagger := New("CopyrightCorpus.in")
-	/*
-		// print out the trans matrix
-		for row:=0; row < numOfTags; row++ {
-			for col:=0; col < numOfTags; col++ {
-				fmt.Printf( "%.2f  ", copyrightTagger.TransMatrix[row][col] )
-			}
-			fmt.Print( "\n" )
+var copyrightTagger *Tagger
+
+func dumpTransMatrix() {
+	// print out the trans matrix
+	for row:=0; row < numOfTags; row++ {
+		for col:=0; col < numOfTags; col++ {
+			log.Printf( "%.2f  ", copyrightTagger.TransMatrix[row][col] )
 		}
-		fmt.Print( "\n\nTHE WORD DICTIONARY: \n" )
-		// print the dictionary
-		for key := range copyrightTagger.Dictionary {
-			for _, tagObject := range copyrightTagger.Dictionary[key] {
-				fmt.Printf( "%s->%s: %.2f\n", key, tagObject.tag, tagObject.freq )
-			}
-			fmt.Print( "\n" )
+		log.Print( "\n" )
+	}
+	log.Print( "\n\nTHE WORD DICTIONARY: \n" )
+	// print the dictionary
+	for key := range copyrightTagger.Dictionary {
+		for _, tagObject := range copyrightTagger.Dictionary[key] {
+			log.Printf( "%s->%s: %.2f\n", key, tagObject.tag, tagObject.freq )
 		}
-		fmt.Print( "\n" )
-	*/
-
-	// Given a sentence to tag lets see what it prints out:
-	copyrightSymbol := copyrightTagger.Match([]byte("./* Decomposed printf argument list.\n (C) 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n    Foundation, Inc.\n\n  This program is free software; you can redistribute it. and/or modify\n it under the terms of the GNU General Public License. as published by\n  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\nany later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */."))
-	full := copyrightTagger.Match([]byte("/* Decomposed printf argument list.\n Copyright (C) 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n    Foundation, Inc.\n\n  This program is free software; you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\nany later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */"))
-	half := copyrightTagger.Match([]byte("/* Decomposed printf argument list.\n Copyright 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n    Foundation, Inc.\n\n  This program is free software; you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\nany later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */"))
-	none := copyrightTagger.Match([]byte("/* Decomposed printf argument list.\n 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n    Foundation, Inc.\n\n  This program is free software; you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\nany later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */"))
-	lowerCase := copyrightTagger.Match([]byte("/* Decomposed printf argument list.\n (c) 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n    Foundation, Inc.\n\n  This program is free software; you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\nany later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */"))
-	flipped := copyrightTagger.Match([]byte("/* Decomposed printf argument list.\n laksjdf laskdj f;l © Copyright 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n    Foundation, Inc.\n\n  This program is free software; you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\nany later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */"))
-	weird := copyrightTagger.Extract([]byte("Copyright ( C ) 2007 Free Software Foundation , Inc. ( ( copyright ( ( copyright ( ( ( ( ( ( ( copyright ( ( ( ( ( ( ( ( ( ( ( ( copyright ( ( copyright ( ( ( ( ( ( ( ( Copyright ( C ) < ( < < Copyright ( C ) < ("))
-	extractString := copyrightTagger.Extract([]byte("/* Decomposed printf argument list.\n laksjdf laskdj f;l © Copyright 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n    Foundation, Inc.\n\n  This program is free software; you can redistribute it and/or modify\n it under the terms of the GNU General Public License as published by\n  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\nany later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n  You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */"))
-
-	passTest1 := copyrightTagger.Match([]byte("some stuff here. \\(co   Exablox  and Pixar     2018 with the Datto corp."))
-	passTest2 := copyrightTagger.Match([]byte("Copyright (c) IBM       Corporation, 2003,   2008.  All rights reserved.   --")) //saying to save tagged array
-	passTest2Ext := copyrightTagger.Extract([]byte("Copyright (c) IBM       Corporation, 2003,   2008.  All rights reserved.   --"))
-	passTest3 := copyrightTagger.Match([]byte(" Â© 2001-2014 Python Software Foundation</string>")) // staying to save the tagged array
-	passTest3Ext := copyrightTagger.Extract([]byte(" © 2001-2014 Python Software Foundation</string>"))
-	complexExtract := copyrightTagger.Extract([]byte("some stuff here. \\(co Exablox and Pixar 2018 with the Datto corp. In accordance with this laa balh"))
-	passTest5 := copyrightTagger.Extract([]byte(" Â© 2001-2014 Python Software Foundation</string>"))
-	passTest6 := copyrightTagger.Match([]byte("* Copyright 2004 by Theodore Ts'o."))
-	passTest7 := copyrightTagger.Extract([]byte("Copyright (c) 2007, 2008 Alastair Houghton"))
-
-	failTest1 := copyrightTagger.Match([]byte(" #define Copyright sign "))
-	failTest2 := copyrightTagger.Match([]byte("Fetched %sB in %s (%sB/s)\n"))
-	failTest3 := copyrightTagger.Match([]byte("GNU nano version %s (compiled %s, %s)\n"))
-	failTest4 := copyrightTagger.Match([]byte("(c)   "))
-	failTest5 := copyrightTagger.Match([]byte("#define c_tolower(c) \\ "))
-	failTest6 := copyrightTagger.Match([]byte("/* ToUnicode().  May realloc() utf8in.  Will free utf8in unconditionally. */"))
-	failTest7 := copyrightTagger.Match([]byte("COPYRIGHT SIGN */ (1U<<_CC_GRAPH)|(1U<<_CC_PRINT)|(1U<<_CC_QUOTEMETA),"))
-	failTest8 := copyrightTagger.Extract([]byte("Copyright\\ 1989% -1990\\ PKWARE\\ Inc.	Self-extracting PKZIP archive"))
-	failTest9 := copyrightTagger.Match([]byte("( C ( { ( { ( { ( ( { ( ( { ( { < < ( ( ) 0"))
-	failTest10 := copyrightTagger.Extract([]byte("< < ( ( ( ( ( ( ( C ( ( C ( ( ( ( ( ( ( ( ( < < < < < < < < < < < < < < < < ( ( ( ( ( ( ( < ( Copyright ( C ) 1992 - 2009 , Free Software Foundation , Inc. - copyright ( < ( ( ( ( ( < ( < ( ( ( ( ( < ( < ( ( ( ( ( ("))
-	failTest11 := copyrightTagger.Match([]byte(" # '$siteCopyrightName' on line 12, col 24"))
-	failTest13 := copyrightTagger.Extract([]byte("# ifdef _SC_PAGESIZE\n#  define getpagesize() sysconf(_SC_PAGESIZE)\n# else /* no _SC_PAGESIZE */\n#  ifdef HAVE_SYS_PARAM_H\n#   include <sys/param.h>\n#   ifdef EXEC_PAGESIZE\n#    define getpagesize() EXEC_PAGESIZE\n#   else /* no EXEC_PAGESIZE */\n#    ifdef NBPG\n#     define getpagesize() NBPG * CLSIZE\n#     ifndef CLSIZE\n#      define CLSIZE 1\n#     endif /* no CLSIZE */\n#    else /* no NBPG */\n#     ifdef NBPC\n#      define getpagesize() NBPC\n#     else /* no NBPC */\n#      ifdef PAGESIZE\n#       define getpagesize() PAGESIZE\n#      endif /* PAGESIZE */\n#     endif /* no NBPC */\n#    endif /* no NBPG */\n#   endif /* no EXEC_PAGESIZE */\n#  else /* no HAVE_SYS_PARAM_H */\n#   define getpagesize() 8192	/* punt totally */\n#  endif /* no HAVE_SYS_PARAM_H */\n# endif /* no _SC_PAGESIZE */"))
-	failTest14 := copyrightTagger.Extract([]byte("#???????k(?P(???-[?477?????????=?|?ʡ?zRRR?p?B?|^^ޚ5k\n                                                                                                                               RQ??+W?d?͛7?\\?R?P?????}?5@4?W_ϔ?8J`?V>?h?V?\n                                 6?J??????V(x?}?l???)HC??̟?+???p?f>/?5k\n                                                                      ?8+W\"??y3+W??@?>?oaK3?𢡊?????|?ʡ?zRB?Bj???[??T`%+e?6?y%+?cCq?ĉI?&????<yR?G2???ѣ?|?j?Pv=?{?nFF?F>&&?7?0?=?ĉ>?8q?':????tݸq???a??ūV?1b???^TT4iҤ??<?\n                                                                              EEE?_?>66V;?ر#F8p???~????????W_?O7n?,?U0⑵&A??'?`=?v??S????е?Ϡ?                                                                                                           8?x1?V1b??~?\"&MB}??????v??v\n  ?MA??II!;?????op???,^Ū?P?؋(?Ĥ<?1E?z?????Ʊ?                                                                   ?!???M?W]????z\n\n                                                                                                                             ?1cƜ:u???V?>ح[?8???D???&L?????Ϛ5ˀ?????_?????????7??ꕱ?qNN???pjj?T*ճ>???>}??/???????wU??	=?!?Q??T??ݣC?H???<?B?*??~\"??????ޙ75?T??\"z?3}:_|?????tm?q9?v©?J???"))
+		log.Print( "\n" )
+	}
+	log.Print( "\n" )
+}
 
 
+func TestMain(m *testing.M) {
+	copyrightTagger = New("CopyrightCorpus.in")
 
-	fmt.Print("\n")
-	switch {
-	case true != copyrightSymbol:
-		t.Errorf("Copyright symbol not matched\n")
-	case true != full:
-		t.Errorf("Complete Notice not matched\n")
-	case true != half:
-		t.Errorf("partial notice not matched\n")
-	case true != lowerCase:
-		t.Errorf("lower case c not matched\n")
-	case true != flipped:
-		t.Errorf("Name before date not matched\n")
-	case true != passTest1:
-		t.Errorf("Several companies failed\n")
-	case true != passTest2:
-		t.Errorf("Extra spaces failed to pass\n")
-	case true != passTest3:
-		t.Errorf("Copyright symbol\n")
-	case true != passTest6:
-		t.Errorf("Compression on appostrophe test failed\n")
-	case false != none:
-		t.Errorf("No notice failed\n")
-	case false != failTest1:
-		t.Errorf("Copyright but nothing else\n")
-	case false != failTest2:
-		t.Errorf("Percent character\n")
-	case false != failTest3:
-		t.Errorf("Propper noun, with symbols\n")
-	case false != failTest4:
-		t.Errorf("(c) notified as true\n")
-	case false != failTest5:
-		t.Errorf("Accepted C # define\n")
-	case false != failTest6:
-		t.Errorf("Unicode conversion\n")
-	case false != failTest7:
-		t.Errorf("Copyright sign false positive\n")
-	case false != failTest9:
-		t.Errorf("Open parenthesis repetition\n")
-	case false != failTest11:
-		t.Errorf("Open and Close parenthsis repetition\n")
+//	dumpTransMatrix()
 
+	os.Exit(m.Run())
+}
+
+func TestMatch(t *testing.T) {
+	type MatchTest struct {
+		Expected	bool
+		Text		string
 	}
 
-	fmt.Println("Extracting")
-	fmt.Println(extractString)
-	fmt.Println(complexExtract)
-	fmt.Println(passTest2Ext)
-	fmt.Println(passTest3Ext)
-	fmt.Println(weird)
-	fmt.Println(passTest5)
-	fmt.Println(failTest10)
-	fmt.Println(failTest13)
-	fmt.Println("Odd symbols: ", failTest14)
-	fmt.Println("Start: ", passTest7)
 
-	fmt.Println("Should pass: ", failTest8)
+	tests := []MatchTest {
+		{
+			Expected:	true,
+			Text:		"./* Decomposed printf argument list.\n"+
+					" (C) 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n"+
+					"    Foundation, Inc.\n\n  This program is free software; you can redistribute it. and/or modify\n"+
+					" it under the terms of the GNU General Public License. as published by\n"+
+					"  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\n"+
+					"any later version.\n"+
+					"\n"+
+					"This program is distributed in the hope that it will be useful,\n"+
+					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"+
+					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"+
+					"GNU General Public License for more details.\n"+
+					"  You should have received a copy of the GNU General Public License along with this program;"+
+					" if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,"+
+					" Boston, MA 02110-1301, USA.  */.",
+		},
+		{
+			Expected:	true,
+			Text:		"/* Decomposed printf argument list.\n"+
+					" Copyright (C) 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n"+
+					"    Foundation, Inc.\n"+
+					"\n"+
+					"  This program is free software; you can redistribute it and/or modify\n"+
+					" it under the terms of the GNU General Public License as published by\n"+
+					"  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\n"+
+					"any later version.\n"+
+					"\n"+
+					"This program is distributed in the hope that it will be useful,\n"+
+					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"+
+					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"+
+					"GNU General Public License for more details.\n"+
+					"  You should have received a copy of the GNU General Public License along with this program;"+
+					" if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,"+
+					" Boston, MA 02110-1301, USA.  */",
+		},
+		{
+			Expected:	true,
+			Text:		"/* Decomposed printf argument list.\n"+
+					" Copyright 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n"+
+					"    Foundation, Inc.\n"+
+					"\n"+
+					"  This program is free software; you can redistribute it and/or modify\n"+
+					" it under the terms of the GNU General Public License as published by\n"+
+					"  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\n"+
+					"any later version.\n"+
+					"\n"+
+					"This program is distributed in the hope that it will be useful,\n"+
+					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"+
+					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"+
+					"GNU General Public License for more details.\n"+
+					"  You should have received a copy of the GNU General Public License along with this program;"+
+					" if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,"+
+					" Boston, MA 02110-1301, USA.  */",
+		},
+		{
+			Expected:	false,
+			Text:		"/* Decomposed printf argument list.\n"+
+					" 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n"+
+					"    Foundation, Inc.\n"+
+					"\n"+
+					"  This program is free software; you can redistribute it and/or modify\n"+
+					" it under the terms of the GNU General Public License as published by\n"+
+					"  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\n"+
+					"any later version.\n"+
+					"\n"+
+					"This program is distributed in the hope that it will be useful,\n"+
+					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"+
+					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"+
+					"GNU General Public License for more details.\n"+
+					"  You should have received a copy of the GNU General Public License along with this program;"+
+					" if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,"+
+					" Boston, MA 02110-1301, USA.  */",
+		},
+		{
+			Expected:	true,
+			Text:		"/* Decomposed printf argument list.\n"+
+					" (c) 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n"+
+					"    Foundation, Inc.\n"+
+					"\n"+
+					"  This program is free software; you can redistribute it and/or modify\n"+
+					" it under the terms of the GNU General Public License as published by\n"+
+					"  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\n"+
+					"any later version.\n"+
+					"\n"+
+					"This program is distributed in the hope that it will be useful,\n"+
+					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"+
+					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"+
+					"GNU General Public License for more details.\n"+
+					"  You should have received a copy of the GNU General Public License along with this program;"+
+					" if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,"+
+					" Boston, MA 02110-1301, USA.  */",
+		},
+		{
+			Expected:	true,
+			Text:		"/* Decomposed printf argument list.\n"+
+					" laksjdf laskdj f;l © Copyright 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n"+
+					"    Foundation, Inc.\n"+
+					"\n"+
+					"  This program is free software; you can redistribute it and/or modify\n"+
+					" it under the terms of the GNU General Public License as published by\n"+
+					"  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\n"+
+					"any later version.\n"+
+					"\n"+
+					"This program is distributed in the hope that it will be useful,\n"+
+					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"+
+					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"+
+					"GNU General Public License for more details.\n"+
+					"  You should have received a copy of the GNU General Public License along with this program;"+
+					" if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,"+
+					" Boston, MA 02110-1301, USA.  */",
+		},
+		{
+			Expected:	true,
+			Text:		"some stuff here. \\(co   Exablox  and Pixar     2018 with the Datto corp.",
+		},
+		{
+			// saying to save tagged array
+			Expected:	true,
+			Text:		"Copyright (c) IBM       Corporation, 2003,   2008.  All rights reserved.   --",
+		},
+		{
+			// staying to save the tagged array
+			Expected:	true,
+			Text:		" Â© 2001-2014 Python Software Foundation</string>",
+		},
+		{
+			Expected:	true,
+			Text:		"* Copyright 2004 by Theodore Ts'o.",
+		},
+		{
+			Expected:	false,
+			Text:		" #define Copyright sign ",
+		},
+		{
+			Expected:	false,
+			Text:		"Fetched %sB in %s (%sB/s)\n",
+		},
+		{
+			Expected:	false,
+			Text:		"GNU nano version %s (compiled %s, %s)\n",
+		},
+		{
+			Expected:	false,
+			Text:		"(c)   ",
+		},
+		{
+			Expected:	false,
+			Text:		"#define c_tolower(c) \\ ",
+		},
+		{
+			Expected:	false,
+			Text:		"/* ToUnicode().  May realloc() utf8in.  Will free utf8in unconditionally. */",
+		},
+		{
+			Expected:	false,
+			Text:		"COPYRIGHT SIGN */ (1U<<_CC_GRAPH)|(1U<<_CC_PRINT)|(1U<<_CC_QUOTEMETA),",
+		},
+		{
+			Expected:	false,
+			Text:		"( C ( { ( { ( { ( ( { ( ( { ( { < < ( ( ) 0",
+		},
+		{
+			Expected:	false,
+			Text:		" # '$siteCopyrightName' on line 12, col 24",
+		},
+	}
 
-	fmt.Println("FINDING INDICIES")
-	raw := []byte("It's an MIT-style license.  Here goes:\n\nCopyright (c) 2007, 2008 Alastair Houghton\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:")
-	taggedRaw := copyrightTagger.TagBytes(raw)
-	indiciesTest1 := copyrightTagger.FindAllIndex(raw)
-	fmt.Println(taggedRaw)
-	fmt.Println(indiciesTest1)
+	for i, test := range tests {
+		r := copyrightTagger.Match([]byte(test.Text))
+		if r != test.Expected {
+			t.Errorf("Test %d: expected %v got %v", i, test.Expected, r)
+		}
+	}
+}
 
+/*
+ * XXX - Tad: this should probably be more robust than just checking the length of the tagged words array that was returned
+ */
+func TestTagBytes(t *testing.T) {
+	raw := "It's an MIT-style license.  Here goes:\n"+
+		"\n"+
+		"Copyright (c) 2007, 2008 Alastair Houghton\n"+
+		"Permission is hereby granted, free of charge, to any person obtaining a copy\n"+
+		"of this software and associated documentation files (the \"Software\"), to deal\n"+
+		"in the Software without restriction, including without limitation the rights\n"+
+		"to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n"+
+		"copies of the Software, and to permit persons to whom the Software is\n"+
+		"furnished to do so, subject to the following conditions:"
+	nexpected := 108
+
+	twords := copyrightTagger.TagBytes([]byte(raw))
+	if twords == nil {
+		t.Fatalf("expected %d elements, got nil", nexpected)
+	}
+
+	if len(twords) != nexpected {
+		t.Errorf("expected %d elements got %d", nexpected, len(twords))
+	}
+}
+
+func TestFindAllIndex(t *testing.T) {
+	raw := "It's an MIT-style license.  Here goes:\n"+
+		"\n"+
+		"Copyright (c) 2007, 2008 Alastair Houghton\n"+
+		"Permission is hereby granted, free of charge, to any person obtaining a copy\n"+
+		"of this software and associated documentation files (the \"Software\"), to deal\n"+
+		"in the Software without restriction, including without limitation the rights\n"+
+		"to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n"+
+		"copies of the Software, and to permit persons to whom the Software is\n"+
+		"furnished to do so, subject to the following conditions:"
+	expected := [][]int{{40, 94}}
+
+	matches := copyrightTagger.FindAllIndex([]byte(raw))
+	if matches == nil {
+		t.Fatalf("expected array of indexes, got nil")
+	}
+
+	if len(matches) != len(expected) {
+		t.Fatalf("expected %d matches got %d", len(expected), len(matches))
+	}
+
+	for i := 0; i < len(matches); i++ {
+		m := matches[i]
+		e := expected[i]
+		if len(m) != len(e) {
+			t.Errorf("offset %d: index length mismatch: expected %d got %d", i, len(e), len(m))
+			continue
+		}
+		for j := 0; j < len(m); j++ {
+			if m[j] != e[j] {
+				t.Errorf("matches[%d][%d]: expected %d got %d", i, j, e[j], m[j])
+			}
+		}
+	}
+}
+
+/*
+ * XXX - Tad: Needs addition of pass/fail criteria
+ */
+func TestExtract(t *testing.T) {
+	type ExtractTest struct {
+		Expected	string
+		Text		string
+	}
+
+	tests := []ExtractTest {
+		{
+			Expected:	"Copyright ( C ) 2007 Free Copyright ( C ) Copyright ( C )",
+			Text:		"Copyright ( C ) 2007 Free Software Foundation , Inc."+
+					" ( ( copyright ( ( copyright ( ( ( ( ( ( ( copyright ( ( ( ( ( ( ( ( ( ( ( ("+
+					" copyright ( ( copyright ( ( ( ( ( ( ( ( Copyright ( C ) < ( < < Copyright ( C ) < (",
+		},
+		{
+			Expected:	"Copyright 1999 , 2002 - 2003 , 2005 - 2007 , 2009 - 2011 Free",
+			Text:		"/* Decomposed printf argument list.\n"+
+					" laksjdf laskdj f;l © Copyright 1999, 2002-2003, 2005-2007, 2009-2011 Free Software\n"+
+					"    Foundation, Inc.\n"+
+					"\n"+
+					"  This program is free software; you can redistribute it and/or modify\n"+
+					" it under the terms of the GNU General Public License as published by\n"+
+					"  the Free Software Foundation; either version 3.1.2, or 9.3 (at your option)\n"+
+					"any later version.\n"+
+					"\n"+
+					"This program is distributed in the hope that it will be useful,\n"+
+					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n"+
+					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"+
+					"GNU General Public License for more details.\n"+
+					"  You should have received a copy of the GNU General Public License along with this program;"+
+					"if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,"+
+					" Boston, MA 02110-1301, USA.  */",
+		},
+		{
+			Expected:	"Copyright ( c )",
+			Text:		"Copyright (c) IBM       Corporation, 2003,   2008.  All rights reserved.   --",
+		},
+		{
+			Expected:	"© 2001 - 2014 Python Software",
+			Text:		" © 2001-2014 Python Software Foundation</string>",
+		},
+		{
+			Expected:	"( c ) Exablox and Pixar 2018 with the Datto corp. In",
+			Text:		"some stuff here. \\(co Exablox and Pixar 2018 with the Datto corp. In accordance with this laa balh",
+		},
+		{
+			Expected:	"Â© 2001 - 2014 Python Software",
+			Text:		" Â© 2001-2014 Python Software Foundation</string>",
+		},
+		{
+			Expected:	"Copyright ( c ) 2007 , 2008 Alastair Houghton",
+			Text:		"Copyright (c) 2007, 2008 Alastair Houghton",
+		},
+		{
+			Expected:	"Copyright \\ 1989 % - 1990 \\ PKWARE \\ Inc. Self",
+			Text:		"Copyright\\ 1989% -1990\\ PKWARE\\ Inc.	Self-extracting PKZIP archive",
+		},
+		{
+			Expected:	"Copyright ( C ) 1992 - 2009 ,",
+			Text:		"< < ( ( ( ( ( ( ( C ( ( C ( ( ( ( ( ( ( ( ( < < < < < < < < < < < < < < < < ( ( ( ( ( ( ("+
+					" < ( Copyright ( C ) 1992 - 2009 , Free Software Foundation , Inc. - copyright"+
+					" ( < ( ( ( ( ( < ( < ( ( ( ( ( < ( < ( ( ( ( ( (",
+		},
+		{
+			Expected:	"",
+			Text:		"# ifdef _SC_PAGESIZE\n"+
+					"#  define getpagesize() sysconf(_SC_PAGESIZE)\n"+
+					"# else /* no _SC_PAGESIZE */\n"+
+					"#  ifdef HAVE_SYS_PARAM_H\n"+
+					"#   include <sys/param.h>\n"+
+					"#   ifdef EXEC_PAGESIZE\n"+
+					"#    define getpagesize() EXEC_PAGESIZE\n"+
+					"#   else /* no EXEC_PAGESIZE */\n"+
+					"#    ifdef NBPG\n"+
+					"#     define getpagesize() NBPG * CLSIZE\n"+
+					"#     ifndef CLSIZE\n"+
+					"#      define CLSIZE 1\n"+
+					"#     endif /* no CLSIZE */\n"+
+					"#    else /* no NBPG */\n"+
+					"#     ifdef NBPC\n"+
+					"#      define getpagesize() NBPC\n"+
+					"#     else /* no NBPC */\n"+
+					"#      ifdef PAGESIZE\n"+
+					"#       define getpagesize() PAGESIZE\n"+
+					"#      endif /* PAGESIZE */\n"+
+					"#     endif /* no NBPC */\n"+
+					"#    endif /* no NBPG */\n"+
+					"#   endif /* no EXEC_PAGESIZE */\n"+
+					"#  else /* no HAVE_SYS_PARAM_H */\n"+
+					"#   define getpagesize() 8192	/* punt totally */\n"+
+					"#  endif /* no HAVE_SYS_PARAM_H */\n"+
+					"# endif /* no _SC_PAGESIZE */",
+		},
+		{
+			Expected:	"",
+			Text:		"#???????k(?P(???-[?477?????????=?|?ʡ?zRRR?p?B?|^^ޚ5k\n                                                                                                                               RQ??+W?d?͛7?\\?R?P?????}?5@4?W_ϔ?8J`?V>?h?V?\n                                 6?J??????V(x?}?l???)HC??̟?+???p?f>/?5k\n                                                                      ?8+W\"??y3+W??@?>?oaK3?𢡊?????|?ʡ?zRB?Bj???[??T`%+e?6?y%+?cCq?ĉI?&????<yR?G2???ѣ?|?j?Pv=?{?nFF?F>&&?7?0?=?ĉ>?8q?':????tݸq???a??ūV?1b???^TT4iҤ??<?\n                                                                              EEE?_?>66V;?ر#F8p???~????????W_?O7n?,?U0⑵&A??'?`=?v??S????е?Ϡ?                                                                                                           8?x1?V1b??~?\"&MB}??????v??v\n  ?MA??II!;?????op???,^Ū?P?؋(?Ĥ<?1E?z?????Ʊ?                                                                   ?!???M?W]????z\n\n                                                                                                                             ?1cƜ:u???V?>ح[?8???D???&L?????Ϛ5ˀ?????_?????????7??ꕱ?qNN???pjj?T*ճ>???>}??/???????wU??	=?!?Q??T??ݣC?H???<?B?*??~\"??????ޙ75?T??\"z?3}:_|?????tm?q9?v©?J???",
+		},
+	}
+
+	for i, test := range tests {
+		r := copyrightTagger.Extract([]byte(test.Text))
+		if r != test.Expected {
+			t.Errorf("Extract Test %d: expected result %q got %q", i, test.Expected, r)
+		}
+	}
 }


### PR DESCRIPTION
Hi Eric,

This set of changes refactors the tagger unit test cases to work correctly with the unit test infrastructure, as well as does a bunch of cleanup to make the testcases more readable and extensible.
